### PR TITLE
Update page objects for Phase 3B unified multi-select and bottom sheets 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,14 +83,19 @@ Capybara.register_driver :poltergeist do |app|
 end
 # set `DRIVER=poltergeist` on the command line when you want to run headless
 Capybara.default_driver = ENV["DRIVER"].nil? ? :selenium : ENV["DRIVER"].to_sym
-unless ENV["DRIVER"] == "poltergeist"
-  Capybara.javascript_driver = :chrome
-  Capybara.page.driver.browser.manage.window.resize_to(*CONSTANT_WINDOW_SIZE)
-  Capybara.page.driver.browser.manage.timeouts.page_load = 10
-end
+Capybara.javascript_driver = :chrome unless ENV["DRIVER"] == "poltergeist"
 Capybara.save_path = "spec/screenshots/"
 Capybara.app_host = ENV.fetch("HOST", nil)
 Capybara.default_max_wait_time = 5 # this should go back to 3
+
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    unless ENV["DRIVER"] == "poltergeist"
+      Capybara.page.driver.browser.manage.window.resize_to(*CONSTANT_WINDOW_SIZE)
+      Capybara.page.driver.browser.manage.timeouts.page_load = 10
+    end
+  end
+end
 
 # capybara-screenshot configuration options
 Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|

--- a/spec/support/pages/change_other_list_modal.rb
+++ b/spec/support/pages/change_other_list_modal.rb
@@ -1,19 +1,24 @@
 # frozen_string_literal: true
 
 module Pages
-  # edit list page
+  # change other list modal — renders as a bottom sheet
   class ChangeOtherListModal < SitePrism::Page
     include TestSelectors
 
-    element :switch_to_existing_list, :button, text: "Choose existing list"
-    element :switch_to_create_list, :button, text: "Create new list"
+    element :switch_to_existing_list, "[data-test-id='choose-existing-list-link']"
+    element :switch_to_create_list, "[data-test-id='create-new-list-link']"
     element :existing_list_dropdown, "#existingList"
     element :new_list_name_input, "#newListName"
     element :complete, :button, text: "Complete"
     element :cancel, :button, text: "Cancel"
+    element :modal_container, "[data-test-id='change-other-list-modal']"
 
-    def all_links
-      find_all(".btn.btn-link")
+    def has_modal?
+      has_test_id?("change-other-list-modal")
+    end
+
+    def has_no_modal?
+      has_no_test_id?("change-other-list-modal")
     end
   end
 end

--- a/spec/support/pages/edit_list_item.rb
+++ b/spec/support/pages/edit_list_item.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pages
-  # edit list page
+  # edit list item — renders as a bottom sheet on the list page
   class EditListItem < SitePrism::Page
     include TestSelectors
 
@@ -12,10 +12,19 @@ module Pages
     element :content, "#content"
     element :product, "#product"
     element :submit, "button[type='submit']"
+    element :edit_sheet, "[data-test-id='edit-item-sheet']"
 
     # Delegate title to title_field to avoid SitePrism blacklist issue
     def title
       title_field
+    end
+
+    def has_edit_sheet?
+      has_test_id?("edit-item-sheet")
+    end
+
+    def wait_for_sheet
+      wait_for { has_edit_sheet? }
     end
   end
 end

--- a/spec/support/pages/edit_list_items.rb
+++ b/spec/support/pages/edit_list_items.rb
@@ -26,11 +26,11 @@ module Pages
     element :submit, "button[type='submit']"
 
     def create_new_list_link
-      find(".btn.btn-link", text: "Create new list")
+      find_by_test_id("create-new-list-link")
     end
 
     def choose_existing_list_link
-      find(".btn.btn-link", text: "Choose existing list")
+      find_by_test_id("choose-existing-list-link")
     end
   end
 end

--- a/spec/support/pages/list.rb
+++ b/spec/support/pages/list.rb
@@ -28,12 +28,9 @@ module Pages
     element :product_input, "#product"
     element :completed_checkbox, "#completed"
     element :submit_button, "button[type='submit']"
-    element :filter_button, "#filter-by-category-button"
-
     element :close_alert, ".Toastify__close-button.Toastify__close-button--colored"
-    elements :multi_select_buttons, :button, "Select"
-    element :copy_to_list, :button, text: "Copy to list"
-    element :move_to_list, :button, text: "Move to list"
+    element :select_button, "[data-test-id='select-button']"
+    element :multi_select_bar, "[data-test-id='multi-select-bar']"
 
     # has_*? methods for elements that use data-test-* selectors
     def has_filter_option?(filter_name)
@@ -151,12 +148,58 @@ module Pages
     end
 
     def expand_list_item_form
-      find(".btn.btn-link", text: "Add Item").click
+      find_by_test_id("quick-add-expand").click
     end
 
     def multi_select_item(item_name, completed: false)
       item_element = find_list_item(item_name, completed:)
       item_element.find("input").click
+    end
+
+    def toggle_multi_select
+      find_by_test_id("select-button").click
+    end
+
+    def edit_item_via_sheet(item_name)
+      item_element = find_list_item(item_name, completed: false)
+      item_element.find(EDIT_BUTTON).click
+      wait_for { has_test_id?("edit-item-sheet") }
+    end
+
+    def copy_to_list_button
+      find_by_test_id("copy-to-list")
+    end
+
+    def move_to_list_button
+      find_by_test_id("move-to-list")
+    end
+
+    def bulk_edit_button
+      find_by_test_id("bulk-edit")
+    end
+
+    def complete_selected_button
+      find_by_test_id("complete-selected")
+    end
+
+    def delete_selected_button
+      find_by_test_id("delete-selected")
+    end
+
+    def refresh_selected_button
+      find_by_test_id("refresh-selected")
+    end
+
+    def has_multi_select_bar?
+      has_test_id?("multi-select-bar")
+    end
+
+    def has_no_multi_select_bar?
+      has_no_test_id?("multi-select-bar")
+    end
+
+    def quick_add_input
+      find_by_test_id("quick-add-input")
     end
 
     def wait_until_confirm_delete_button_visible


### PR DESCRIPTION
- list.rb: Replace Bootstrap selectors with test-id selectors for
  multi-select (unified Select button, MultiSelectBar actions),
  quick-add input, and edit-via-sheet flow
- edit_list_item.rb: Add bottom sheet support (edit-item-sheet test-id)
- edit_list_items.rb: Replace Bootstrap link selectors with test-ids
- change_other_list_modal.rb: Replace Bootstrap selectors with test-ids

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>