### PR TITLE
UI Redesign 3C.2: update templates page selectors

### DIFF
--- a/spec/support/pages/edit_template.rb
+++ b/spec/support/pages/edit_template.rb
@@ -7,7 +7,7 @@ module Pages
 
     set_url "/templates/{id}/edit"
 
-    element :header, "h1", text: "Edit Template"
+    element :header, "h2", text: "Edit Template"
     element :submit, "button[type='submit']"
 
     def template_name_input

--- a/spec/support/pages/templates.rb
+++ b/spec/support/pages/templates.rb
@@ -27,7 +27,7 @@ module Pages
     end
 
     def template_names
-      all_by_test_class("template").map { |t| t.find("h5").text }
+      all_by_test_class("template").map { |t| t.find("h3").text }
     end
 
     def template_name_input


### PR DESCRIPTION
## Summary
- Update \`templates.rb\` to read template names from \`<h3>\` (was \`<h5>\`); \`edit_template.rb\` header element looks at the BottomSheet \`<h2>\` (was the page-level \`<h1>\`).
- \`share_list.rb\` and \`edit_list.rb\` selectors continue to work unchanged because URL navigation still auto-opens each sheet and the existing \`data-test-id\`s / \`#name\` / \`[type='submit']\` are preserved.

## Test plan
- [ ] \`bundle exec rubocop spec/support/pages/{share_list,templates,edit_template,edit_list}.rb\`
- [ ] Run feature suite once the companion client PR (\`cbrenner04/groceries-client#691\`) is deployed to staging

Generated with Claude Code