### PR TITLE
Align e2e specs with redesigned create form and primary fields

### DIFF
--- a/spec/features/list_items/book_list_items_spec.rb
+++ b/spec/features/list_items/book_list_items_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe "A book list item", type: :feature do
 
   def input_new_item_attributes(new_list_item)
     list_page.author_input.set(new_list_item.author)
-    list_page.title_input.set(new_list_item.title)
+    list_page.quick_add_input.set(new_list_item.title)
     list_page.number_in_series_input.set(new_list_item.number_in_series.to_s)
 
     expect(list_page.author_input.value).to eq new_list_item.author
-    expect(list_page.title_input.value).to eq new_list_item.title
+    expect(list_page.quick_add_input.value).to eq new_list_item.title
     expect(list_page.number_in_series_input.value).to eq new_list_item.number_in_series.to_s # input value is a string
   end
 
   def confirm_form_cleared
     expect(list_page.author_input.value).to eq ""
-    expect(list_page.title_input.value).to eq ""
+    expect(list_page.quick_add_input.value).to eq ""
     expect(list_page.category_input.value).to eq ""
     expect(list_page.number_in_series_input.value).to eq ""
     expect(list_page.completed_checkbox).not_to be_checked
@@ -48,7 +48,7 @@ RSpec.describe "A book list item", type: :feature do
       list_page.expand_list_item_form
 
       expect(list_page).to have_author_input
-      expect(list_page).to have_title_input
+      expect(list_page).to have_quick_add_input
       expect(list_page).to have_submit_button
       expect(list_page).to have_multi_select_buttons
       expect(not_completed_item).to have_css list_page.complete_button_css
@@ -71,7 +71,7 @@ RSpec.describe "A book list item", type: :feature do
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
       expect(list_page).to have_no_author_input
-      expect(list_page).to have_no_title_input
+      expect(list_page).to have_no_quick_add_input
       expect(list_page).to have_no_submit_button
       expect(list_page).to have_no_multi_select_buttons
       expect(not_completed_item).to have_no_css list_page.complete_button_css

--- a/spec/features/list_items/grocery_list_items_spec.rb
+++ b/spec/features/list_items/grocery_list_items_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe "A grocery list item", type: :feature do
 
   def input_new_item_attributes(new_list_item)
     list_page.quantity_input.set(new_list_item.quantity)
-    list_page.product_input.set(new_list_item.product)
+    list_page.quick_add_input.set(new_list_item.product)
 
     expect(list_page.quantity_input.value).to eq new_list_item.quantity
-    expect(list_page.product_input.value).to eq new_list_item.product
+    expect(list_page.quick_add_input.value).to eq new_list_item.product
   end
 
   def confirm_form_cleared
     expect(list_page.quantity_input.value).to eq ""
-    expect(list_page.product_input.value).to eq ""
+    expect(list_page.quick_add_input.value).to eq ""
     expect(list_page.category_input.value).to eq ""
     expect(list_page.completed_checkbox).not_to be_checked
   end
@@ -48,7 +48,7 @@ RSpec.describe "A grocery list item", type: :feature do
       list_page.expand_list_item_form
 
       expect(list_page).to have_quantity_input
-      expect(list_page).to have_product_input
+      expect(list_page).to have_quick_add_input
       expect(list_page).to have_submit_button
       expect(list_page).to have_multi_select_buttons
       expect(not_completed_item).to have_css list_page.complete_button_css
@@ -72,7 +72,7 @@ RSpec.describe "A grocery list item", type: :feature do
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
       expect(list_page).to have_no_quantity_input
-      expect(list_page).to have_no_product_input
+      expect(list_page).to have_no_quick_add_input
       expect(list_page).to have_no_submit_button
       expect(list_page).to have_no_multi_select_buttons
       expect(not_completed_item).to have_no_css list_page.complete_button_css

--- a/spec/features/list_items/music_list_items_spec.rb
+++ b/spec/features/list_items/music_list_items_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "A music list item", type: :feature do
   let(:list) { Models::List.new(template_name: "music list template", owner_id: user.id) }
 
   def input_new_item_attributes(new_list_item)
-    list_page.title_input.set(new_list_item.title)
+    list_page.quick_add_input.set(new_list_item.title)
     list_page.artist_input.set(new_list_item.artist)
     list_page.album_input.set(new_list_item.album)
 
-    expect(list_page.title_input.value).to eq new_list_item.title
+    expect(list_page.quick_add_input.value).to eq new_list_item.title
     expect(list_page.artist_input.value).to eq new_list_item.artist
     expect(list_page.album_input.value).to eq new_list_item.album
   end
 
   def confirm_form_cleared
-    expect(list_page.title_input.value).to eq ""
+    expect(list_page.quick_add_input.value).to eq ""
     expect(list_page.artist_input.value).to eq ""
     expect(list_page.album_input.value).to eq ""
     expect(list_page.category_input.value).to eq ""
@@ -48,7 +48,7 @@ RSpec.describe "A music list item", type: :feature do
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
       list_page.expand_list_item_form
-      expect(list_page).to have_title_input
+      expect(list_page).to have_quick_add_input
       expect(list_page).to have_artist_input
       expect(list_page).to have_album_input
       expect(list_page).to have_submit_button
@@ -72,7 +72,7 @@ RSpec.describe "A music list item", type: :feature do
       not_completed_item = list_page.find_list_item(@list_items.first)
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
-      expect(list_page).to have_no_title_input
+      expect(list_page).to have_no_quick_add_input
       expect(list_page).to have_no_artist_input
       expect(list_page).to have_no_album_input
       expect(list_page).to have_no_submit_button

--- a/spec/features/list_items/simple_list_items_spec.rb
+++ b/spec/features/list_items/simple_list_items_spec.rb
@@ -13,15 +13,15 @@ RSpec.describe "A simple list item", type: :feature do
 
   def input_new_item_attributes(new_list_item)
     wait_for do
-      list_page.content_input.set(new_list_item.content)
-      list_page.content_input.value == new_list_item.content
+      list_page.quick_add_input.set(new_list_item.content)
+      list_page.quick_add_input.value == new_list_item.content
     end
 
-    expect(list_page.content_input.value).to eq new_list_item.content
+    expect(list_page.quick_add_input.value).to eq new_list_item.content
   end
 
   def confirm_form_cleared
-    expect(list_page.content_input.value).to eq ""
+    expect(list_page.quick_add_input.value).to eq ""
     expect(list_page.category_input.value).to eq ""
     expect(list_page.completed_checkbox).not_to be_checked
   end
@@ -46,7 +46,7 @@ RSpec.describe "A simple list item", type: :feature do
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
       list_page.expand_list_item_form
-      expect(list_page).to have_content_input
+      expect(list_page).to have_quick_add_input
       expect(list_page).to have_submit_button
       expect(list_page).to have_multi_select_buttons
       expect(not_completed_item).to have_css list_page.complete_button_css
@@ -69,7 +69,7 @@ RSpec.describe "A simple list item", type: :feature do
       not_completed_item = list_page.find_list_item(@list_items.first)
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
-      expect(list_page).to have_no_content_input
+      expect(list_page).to have_no_quick_add_input
       expect(list_page).to have_no_submit_button
       expect(list_page).to have_no_multi_select_buttons
       expect(not_completed_item).to have_no_css list_page.complete_button_css

--- a/spec/features/list_items/to_do_list_items_spec.rb
+++ b/spec/features/list_items/to_do_list_items_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "A to do list item", type: :feature do
   let(:list) { Models::List.new(template_name: "to do list template", owner_id: user.id) }
 
   def input_new_item_attributes(new_list_item)
-    list_page.task_input.set(new_list_item.task)
+    list_page.quick_add_input.set(new_list_item.task)
     list_page.assignee_input.set(new_list_item.assignee_email)
     list_page.due_by_input.set(new_list_item.due_by.strftime("%m/%d/%Y"))
 
-    expect(list_page.task_input.value).to eq new_list_item.task
+    expect(list_page.quick_add_input.value).to eq new_list_item.task
     expect(list_page.assignee_input.value).to eq new_list_item.assignee_email
     expect(list_page.due_by_input.value).to eq new_list_item.due_by.strftime("%Y-%m-%d")
   end
 
   def confirm_form_cleared
-    expect(list_page.task_input.value).to eq ""
+    expect(list_page.quick_add_input.value).to eq ""
     expect(list_page.assignee_input.value).to eq ""
     expect(list_page.due_by_input.value).to eq ""
     expect(list_page.category_input.value).to eq ""
@@ -49,7 +49,7 @@ RSpec.describe "A to do list item", type: :feature do
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
       list_page.expand_list_item_form
-      expect(list_page).to have_task_input
+      expect(list_page).to have_quick_add_input
       expect(list_page).to have_submit_button
       expect(list_page).to have_multi_select_buttons
       expect(not_completed_item).to have_css list_page.complete_button_css
@@ -72,7 +72,7 @@ RSpec.describe "A to do list item", type: :feature do
       not_completed_item = list_page.find_list_item(@list_items.first)
       completed_item = list_page.find_list_item(@list_items.last, completed: true)
 
-      expect(list_page).to have_no_task_input
+      expect(list_page).to have_no_quick_add_input
       expect(list_page).to have_no_submit_button
       expect(list_page).to have_no_multi_select_buttons
       expect(not_completed_item).to have_no_css list_page.complete_button_css

--- a/spec/support/models/book_list_item.rb
+++ b/spec/support/models/book_list_item.rb
@@ -23,8 +23,8 @@ module Models
 
     def pretty_title
       read_str = read ? "true" : "false"
-      secondary = "#{title}·#{number_in_series}·#{read_str}"
-      base = "#{author}\n#{secondary}"
+      secondary = "#{author}·#{number_in_series}·#{read_str}"
+      base = "#{title}\n#{secondary}"
       category ? "#{base}\n#{category}" : base
     end
 

--- a/spec/support/models/grocery_list_item.rb
+++ b/spec/support/models/grocery_list_item.rb
@@ -20,7 +20,7 @@ module Models
     end
 
     def pretty_title
-      base = "#{quantity}\n#{product}"
+      base = "#{product}\n#{quantity}"
       category ? "#{base}\n#{category}" : base
     end
 

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -7,12 +7,12 @@ module Models
   class User
     TEMPLATE_DEFINITIONS = {
       "grocery list template" => [
-        { label: "quantity", data_type: "free_text", position: 1, primary: true },
-        { label: "product", data_type: "free_text", position: 2, primary: false }
+        { label: "product", data_type: "free_text", position: 1, primary: true },
+        { label: "quantity", data_type: "free_text", position: 2, primary: false }
       ],
       "book list template" => [
-        { label: "author", data_type: "free_text", position: 1, primary: true },
-        { label: "title", data_type: "free_text", position: 2, primary: false },
+        { label: "title", data_type: "free_text", position: 1, primary: true },
+        { label: "author", data_type: "free_text", position: 2, primary: false },
         { label: "number in series", data_type: "number", position: 3, primary: false },
         { label: "read", data_type: "boolean", position: 4, primary: false }
       ],

--- a/spec/support/pages/list.rb
+++ b/spec/support/pages/list.rb
@@ -28,7 +28,10 @@ module Pages
     element :content_input, "#content"
     element :product_input, "#product"
     element :completed_checkbox, "#completed"
-    element :submit_button, "button[type='submit']"
+    # The primary/name field is the always-visible bottom input bar (outside the form DOM),
+    # and the form is submitted via the bar's submit button rather than a native submit input.
+    element :quick_add_input, "[data-test-id='quick-add-input']"
+    element :submit_button, "[data-test-id='quick-add-submit']"
     element :close_alert, ".Toastify__close-button.Toastify__close-button--colored"
     element :select_button, "[data-test-id='select-button']"
     element :multi_select_bar, "[data-test-id='multi-select-bar']"
@@ -218,10 +221,6 @@ module Pages
 
     def has_no_multi_select_bar?
       has_no_test_id?("multi-select-bar")
-    end
-
-    def quick_add_input
-      find_by_test_id("quick-add-input")
     end
 
     def wait_until_confirm_delete_button_visible

--- a/spec/support/pages/templates.rb
+++ b/spec/support/pages/templates.rb
@@ -8,14 +8,16 @@ module Pages
     set_url "/templates"
 
     element :header, "h1", text: "Templates"
-    element :submit, "button[type='submit']"
+    # Templates are created via the always-visible bottom input bar; its submit button is
+    # rendered by the bar (data-test-id) rather than a native submit input.
+    element :submit, "[data-test-id='quick-add-submit']"
 
     def manage_templates
       find_by_test_id("nav-templates").click
     end
 
     def expand_template_form
-      find_by_test_id("add-template-button").click
+      find_by_test_id("quick-add-expand").click
     end
 
     def has_templates?
@@ -31,7 +33,7 @@ module Pages
     end
 
     def template_name_input
-      find_by_test_id("template-form-name")
+      find_by_test_id("quick-add-input")
     end
 
     def field_configuration_rows
@@ -45,7 +47,10 @@ module Pages
 
     def delete(template_name)
       template_element = find_by_test_class("template", text: template_name)
-      find_by_test_id_within(template_element, "template-trash").click
+      trash = find_by_test_id_within(template_element, "template-trash")
+      # The fixed bottom "create template" bar overlaps a freshly added template's actions, so a
+      # normal click is intercepted. Center it and click via JS to trigger the button's handler.
+      trash.execute_script("this.scrollIntoView({ block: 'center' }); this.click();")
     end
 
     def confirm_delete_button


### PR DESCRIPTION
## Summary
After the `groceries-client` redesign, 20 feature specs were failing. The redesign moves each list/template's **primary** field into the always-visible bottom input bar and submits via that bar's button, while the expanded form now holds only the **non-primary** fields. These changes update the test layer to match — no app behavior changed.

## Root cause
The test fixtures had stale primary-field definitions. `spec/support/models/user.rb` seeded **grocery** with `quantity` primary and **book** with `author` primary, but the service's canonical templates mark **product** and **title** primary. The redesign surfacing the primary field in the bottom bar exposed this.

## Changes (test-only)
- **List page object** — read the primary field from `quick-add-input`; submit via `quick-add-submit` instead of a native submit input.
- **List-item specs** — enter the primary field through the bar; assert on `quick-add-input` presence.
- **Templates page object** — create via the bottom bar (`quick-add-expand` / `quick-add-input` / `quick-add-submit`); scroll + JS-click the trash icon, which the fixed bottom bar would otherwise intercept on a freshly added template.
- **User fixture** — corrected grocery (`product`) and book (`title`) primary fields and positions to match the service.
- **grocery/book `pretty_title`** — reordered to match the rendered label (primary first), keeping bulk-edit assertions accurate.

## Verification
- The 20 originally-failing tests: **20/20 pass**.
- Full regression sweep across every feature spec file: **162 examples, 0 failures**.
- `rubocop`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
