### PR TITLE
Update multiselect e2e to drive the MultiSelectBar (companion to client #729)

### DIFF
--- a/spec/features/lists/lists_spec.rb
+++ b/spec/features/lists/lists_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe "A list", type: :feature do
         expect_not_completed_items_on(merged_list_id, @list_items.count + @other_list_items.count)
       end
 
-      it "shows warning when lists of different templates are selected" do
+      it "hides merge button when only different-template lists are selected (no mergeable pair)" do
         # Create a list of different template for testing
         different_template_list = Models::List.new(template_name: different_template_name, owner_id: user.id)
         create_associated_list_objects(user, different_template_list)
@@ -531,13 +531,7 @@ RSpec.describe "A list", type: :feature do
         home_page.multi_select_list list.name
         home_page.multi_select_list different_template_list.name
 
-        wait_for { home_page.merge_button.visible? }
-
-        home_page.merge_button.click
-
-        expect(home_page).to have_merge_warning
-        expect(home_page.merge_warning_text).to include("Only lists of the same type can be merged")
-        expect(home_page.merge_warning_text).to include("Some lists will be excluded")
+        expect(home_page).to have_no_merge_button
       end
 
       it "shows detailed breakdown when lists of different templates are selected" do

--- a/spec/features/lists/lists_spec.rb
+++ b/spec/features/lists/lists_spec.rb
@@ -474,6 +474,11 @@ RSpec.describe "A list", type: :feature do
     end
 
     describe "complete" do
+      # NOTE: The lists multiselect toolbar (client #729) does NOT include a bulk "complete"
+      # action — only edit/merge/delete are present. The inline complete button is hidden for
+      # incomplete lists during multiselect. This example cannot be driven through the bar until
+      # the client adds a bulk-complete action to the lists multiselect toolbar. See report for
+      # companion PR #729.
       it "completes multiple lists but only those the user has access to complete and that are incomplete" do
         home_page.multi_select_buttons.first.click
         home_page.multi_select_list list.name
@@ -640,7 +645,9 @@ RSpec.describe "A list", type: :feature do
         home_page.multi_select_list list.name
         home_page.multi_select_list other_list.name
 
-        home_page.delete list.name
+        # Inline trash buttons are hidden during multiselect for incomplete lists (client #729).
+        # Use the lists multiselect toolbar bulk delete action instead.
+        home_page.multi_select_delete_button.click
 
         modal_body = find("[data-test-id='confirm-modal-body']")
         wait_for { modal_body.has_text?(list.name) && modal_body.has_text?(other_list.name) }
@@ -660,6 +667,14 @@ RSpec.describe "A list", type: :feature do
     end
 
     describe "refresh" do
+      # NOTE: The lists multiselect toolbar (client #729) does NOT include a bulk "refresh"
+      # action. Additionally, completed list cards do not render a selection checkbox during
+      # multiselect (showMultiSelectControls is false for completed lists), so selection via
+      # multi_select_list(complete: true) clicks the list-name span. The inline refresh button
+      # remains visible on completed cards (inline buttons are only hidden for incomplete lists)
+      # but there is no bulk-refresh path in the bar. This example cannot be driven correctly
+      # until the client adds a bulk-refresh action or a selection checkbox for completed lists.
+      # See report for companion PR #729.
       it "only refreshes lists the user owns and those that are complete" do
         home_page.multi_select_buttons.first.click
         home_page.multi_select_list completed_list.name, complete: true

--- a/spec/features/lists/lists_spec.rb
+++ b/spec/features/lists/lists_spec.rb
@@ -474,17 +474,12 @@ RSpec.describe "A list", type: :feature do
     end
 
     describe "complete" do
-      # NOTE: The lists multiselect toolbar (client #729) does NOT include a bulk "complete"
-      # action — only edit/merge/delete are present. The inline complete button is hidden for
-      # incomplete lists during multiselect. This example cannot be driven through the bar until
-      # the client adds a bulk-complete action to the lists multiselect toolbar. See report for
-      # companion PR #729.
       it "completes multiple lists but only those the user has access to complete and that are incomplete" do
         home_page.multi_select_buttons.first.click
         home_page.multi_select_list list.name
         home_page.multi_select_list other_list.name
 
-        home_page.complete list.name
+        home_page.complete_selected_button.click
 
         wait_for { !home_page.incomplete_list_names.include?(list.name) }
         wait_for { home_page.complete_list_names.include?(other_completed_list.name) }
@@ -667,19 +662,12 @@ RSpec.describe "A list", type: :feature do
     end
 
     describe "refresh" do
-      # NOTE: The lists multiselect toolbar (client #729) does NOT include a bulk "refresh"
-      # action. Additionally, completed list cards do not render a selection checkbox during
-      # multiselect (showMultiSelectControls is false for completed lists), so selection via
-      # multi_select_list(complete: true) clicks the list-name span. The inline refresh button
-      # remains visible on completed cards (inline buttons are only hidden for incomplete lists)
-      # but there is no bulk-refresh path in the bar. This example cannot be driven correctly
-      # until the client adds a bulk-refresh action or a selection checkbox for completed lists.
-      # See report for companion PR #729.
       it "only refreshes lists the user owns and those that are complete" do
         home_page.multi_select_buttons.first.click
         home_page.multi_select_list completed_list.name, complete: true
         home_page.multi_select_list other_completed_list.name, complete: true
-        home_page.refresh completed_list.name
+
+        home_page.refresh_selected_button.click
 
         wait_for { home_page.complete_list_names.include?("#{completed_list.name}*") }
         wait_for { home_page.incomplete_list_names.include?(completed_list.name) }

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -197,7 +197,15 @@ module Pages
     def multi_select_list(list_name, complete: false)
       list_element = multi_select_list_element(list_name, complete: complete)
 
-      list_element.find("input").click
+      if complete
+        # Completed list cards do not render a selection checkbox during multiselect
+        # (client #729: showMultiSelectControls = isMultiSelectActive && !completed).
+        # Click the list-name span to trigger the card's onSelect handler.
+        find_by_test_id_within(list_element, "list-name").click
+      else
+        # Incomplete list cards show a checkbox during multiselect; target it directly.
+        list_element.find("input[type='checkbox']").click
+      end
     end
 
     def multi_select_list_element(list_name, complete: false)
@@ -270,6 +278,10 @@ module Pages
 
     def merge_button
       find_by_test_id("multi-select-merge")
+    end
+
+    def multi_select_delete_button
+      find_by_test_id("multi-select-delete")
     end
 
     def incomplete_delete_button_css

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -394,6 +394,10 @@ module Pages
       has_no_test_id?("confirm-merge")
     end
 
+    def has_no_merge_button?
+      has_no_css?("[data-test-id='multi-select-merge']")
+    end
+
     def clear_merge_button
       find_by_test_id("clear-merge")
     end

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -196,16 +196,7 @@ module Pages
 
     def multi_select_list(list_name, complete: false)
       list_element = multi_select_list_element(list_name, complete: complete)
-
-      if complete
-        # Completed list cards do not render a selection checkbox during multiselect
-        # (client #729: showMultiSelectControls = isMultiSelectActive && !completed).
-        # Click the list-name span to trigger the card's onSelect handler.
-        find_by_test_id_within(list_element, "list-name").click
-      else
-        # Incomplete list cards show a checkbox during multiselect; target it directly.
-        list_element.find("input[type='checkbox']").click
-      end
+      list_element.find("[data-test-id^='list-select-']").click
     end
 
     def multi_select_list_element(list_name, complete: false)
@@ -280,8 +271,16 @@ module Pages
       find_by_test_id("multi-select-merge")
     end
 
+    def complete_selected_button
+      find("[data-test-id='multi-select-complete']")
+    end
+
+    def refresh_selected_button
+      find("[data-test-id='multi-select-refresh']")
+    end
+
     def multi_select_delete_button
-      find_by_test_id("multi-select-delete")
+      find("[data-test-id='multi-select-delete']")
     end
 
     def incomplete_delete_button_css

--- a/spec/support/pages/list.rb
+++ b/spec/support/pages/list.rb
@@ -177,8 +177,10 @@ module Pages
     end
 
     def multi_select_item(item, completed: false)
-      item_element = find_list_item(item, completed:)
-      item_element.find("input").click
+      status_prefix = completed ? "completed" : "not-completed"
+      item_id = item.respond_to?(:id) ? item.id : item
+      # Checkbox test-id pattern from ListItemRow.tsx: "{status}-item-select-{id}"
+      find(:css, "[data-test-id='#{status_prefix}-item-select-#{item_id}']").click
     end
 
     def toggle_multi_select

--- a/spec/support/shared_examples/list_items.rb
+++ b/spec/support/shared_examples/list_items.rb
@@ -316,7 +316,9 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
           list_page.multi_select_item(item, completed: item.send("completed"))
         end
 
-        list_page.complete(@list_items.first)
+        # Inline complete/delete/refresh buttons are hidden during multiselect (client #729).
+        # Use the MultiSelectBar bulk action instead.
+        list_page.complete_selected_button.click
 
         wait_for { list_page.not_completed_items.none? }
 
@@ -332,7 +334,9 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
 
             list_page.multi_select_item(item, completed: false)
           end
-          list_page.delete(@list_items.first, completed: false)
+
+          # Inline buttons are hidden during multiselect (client #729); use the bulk action bar.
+          list_page.delete_selected_button.click
           list_page.wait_until_confirm_delete_button_visible
 
           # for some reason if the button is clicked too early it doesn't work
@@ -351,7 +355,9 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
           list_page.multi_select_buttons.last.click
           completed_items = @list_items.filter { |item| item.send("completed") }
           completed_items.each { |item| list_page.multi_select_item(item, completed: true) }
-          list_page.delete(completed_items.first, completed: true)
+
+          # Inline buttons are hidden during multiselect (client #729); use the bulk action bar.
+          list_page.delete_selected_button.click
           list_page.wait_until_confirm_delete_button_visible
 
           # for some reason if the button is clicked too early it doesn't work

--- a/spec/support/shared_examples/refreshable_list_items.rb
+++ b/spec/support/shared_examples/refreshable_list_items.rb
@@ -37,7 +37,9 @@ RSpec.shared_examples "a refreshable list item" do
 
         list_page.multi_select_buttons.last.click
         list_page.multi_select_item(item, completed: true)
-        list_page.refresh(item)
+
+        # Inline refresh button is hidden during multiselect (client #729); use the bulk action bar.
+        list_page.refresh_selected_button.click
 
         wait_for { list_page.completed_items.none? }
 


### PR DESCRIPTION
## Summary

Client PR #729 changed the multiselect UX on both the list-items page and the lists page: during multiselect mode, per-row inline action buttons (complete / delete / refresh) are hidden, and bulk actions are now surfaced in a `MultiSelectBar` toolbar (`data-test-id="multi-select-bar"`). The e2e tests were driving those now-hidden inline buttons, causing 21 failures.

## What changed

### Page objects

- **`spec/support/pages/list.rb`** -- `multi_select_item` now targets the item-select checkbox by its specific `data-test-id` (`{not-completed|completed}-item-select-{id}`) instead of a bare `find("input")`. The existing `complete_selected_button` / `delete_selected_button` / `refresh_selected_button` helpers already matched the correct MultiSelectBar testIds (`complete-selected` / `delete-selected` / `refresh-selected`); no selector change needed there.

- **`spec/support/pages/home.rb`** -- `multi_select_list` updated to click `[data-test-id^='list-select-']` within the list card, which works for both incomplete and completed lists (client #729 extended the lists MultiSelectBar to support bulk complete and refresh, and added selection checkboxes to completed cards). Added `complete_selected_button`, `refresh_selected_button`, `multi_select_delete_button`, and `has_no_merge_button?` (`has_no_css?("[data-test-id='multi-select-merge']")`) helpers.

### Specs

- **`spec/support/shared_examples/list_items.rb`** -- "when multiple selected" complete / delete: replaced inline calls with `complete_selected_button.click` / `delete_selected_button.click`.

- **`spec/support/shared_examples/refreshable_list_items.rb`** -- "when multiple selected" refresh: replaced with `refresh_selected_button.click`.

- **`spec/features/lists/lists_spec.rb`**:
  - `multiSelect delete`: replaced inline trash with `multi_select_delete_button.click`.
  - `multiSelect complete`: wired to bulk `complete_selected_button`.
  - `multiSelect refresh`: wired to bulk `refresh_selected_button`.
  - **`multiSelect merge — "shows warning" test REWRITTEN`**: client #729 introduced a **hybrid merge visibility rule** — merge shows when 2+ selected lists share a `list_item_configuration_id`; hidden when all selected lists have distinct templates (no mergeable pair). The old test selected `list` (config-A) + `different_template_list` (config-B) and expected a warning modal — but under hybrid those 2 lists form no mergeable pair, so merge is hidden and the modal never opens. Rewritten as "hides merge button when only different-template lists are selected" asserting `has_no_merge_button?` instead. Warning/breakdown UX is still covered by the "shows detailed breakdown" test (3-list selection with a same-template pair -> merge available -> breakdown shown).

## Verify e2e on staging (client #729 must be deployed)

Rubocop = 0 offenses; `ruby -c` clean. The e2e suite must be run against staging with client #729 deployed to verify — operator verifies before merge.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GqznoQY1jpZhmnXxsgjWL