### PR TITLE
Dismiss category combobox suggestions before clicking completed (companion to client #740)

### DIFF
--- a/spec/support/shared_examples/list_items.rb
+++ b/spec/support/shared_examples/list_items.rb
@@ -80,6 +80,10 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
       # Input item attributes
       send("input_new_item_attributes", new_list_item)
       list_page.category_input.set(new_list_item.category)
+      # The category field is now a combobox (client #740); typing an existing category opens a
+      # suggestions dropdown that overlays the fields below it. Dismiss it (Escape preserves the
+      # typed value) so it does not intercept the completed checkbox click.
+      list_page.category_input.send_keys(:escape)
 
       # Check the completed checkbox
       list_page.completed_checkbox.click


### PR DESCRIPTION
## Why

Client #740 turned the item-form Category field into a combobox. In the shared
`list_items` example **"is created as completed when checkbox is checked"**, the test
sets the category to `"foo"` (an existing category), which opens the suggestions
dropdown. Capybara's `.set` leaves focus in the field, so the dropdown stays open and
its absolutely-positioned `<li role="option">` overlays the completed checkbox directly
below it. Selenium then fails the checkbox click with `ElementClickInterceptedError`
(a human's click blurs the field first, closing the dropdown — which is why it passes
manually).

## Fix

Send `Escape` to the category input after setting it. The combobox closes the dropdown
on Escape **while preserving the typed value**, so the completed checkbox is clickable
and the item is still saved with category `foo`. No client change needed — the combobox
behaves correctly for real users.
