### PR TITLE
[codex] fix staging multiselect list setup

### DIFF
--- a/spec/features/lists/lists_spec.rb
+++ b/spec/features/lists/lists_spec.rb
@@ -471,6 +471,8 @@ RSpec.describe "A list", type: :feature do
       @other_completed_list_items = create_associated_list_objects(user, other_completed_list)
       DB[:users_lists].where(user_id: user.id, list_id: other_list.id).update(permissions: "read")
       page.refresh
+      wait_for { home_page.incomplete_list_names.include?(list.name) }
+      wait_for { home_page.incomplete_list_names.include?(other_list.name) }
     end
 
     describe "complete" do

--- a/spec/support/pages/home.rb
+++ b/spec/support/pages/home.rb
@@ -14,8 +14,6 @@ module Pages
     element :new_merged_list_name_input, "#mergeName"
     element :header, "[data-test-id='page-title']"
 
-    elements :multi_select_buttons, :button, "Select"
-
     # has_*? methods for elements that use data-test-* selectors
     def has_log_out?
       has_test_id?("log-out-link")
@@ -146,6 +144,13 @@ module Pages
       all_by_test_class("pending-list").map do |list|
         find_by_test_id_within(list, "list-name").text
       end
+    end
+
+    def multi_select_buttons
+      buttons = all_by_test_id("select-button", wait: 0)
+      return buttons if buttons.any?
+
+      all(:button, text: /\ASelect( Lists)?\z/)
     end
 
     # Immediate versions for post-wait_for assertions (no Capybara waiting)


### PR DESCRIPTION
## Summary

Fixes the staging-only multiselect failure where the list page was still settling or the select control label differed from local expectations.

## Root Cause

The failing staging screenshot showed the lists page could still be in a transition/loading state immediately after `page.refresh`, and the rendered home-page multiselect control is currently labeled `Select Lists` without `data-test-id="select-button"`.

## Changes

- Wait for both expected incomplete lists after refreshing the home page in the multiselect setup.
- Update the home page object to prefer `data-test-id="select-button"`, while falling back to the semantic `Select` / `Select Lists` button label for staging compatibility.

## Validation

- `ENV=staging HEADLESS=true bundle exec rspec spec/features/lists/lists_spec.rb -e 'completes multiple lists' -e 'merges all selected lists' --format documentation`
- `bundle exec rubocop`