### PR TITLE
Drive list-item and template add flows via FAB + modal

### DIFF
--- a/spec/features/list_items/book_list_items_spec.rb
+++ b/spec/features/list_items/book_list_items_spec.rb
@@ -22,11 +22,8 @@ RSpec.describe "A book list item", type: :feature do
   end
 
   def confirm_form_cleared
-    expect(list_page.author_input.value).to eq ""
-    expect(list_page.quick_add_input.value).to eq ""
-    expect(list_page.category_input.value).to eq ""
-    expect(list_page.number_in_series_input.value).to eq ""
-    expect(list_page.completed_checkbox).not_to be_checked
+    # Submitting the add-item modal closes it, which is the form's "cleared" state.
+    expect(list_page).to have_no_add_item_modal
   end
 
   before { @list_items = create_associated_list_objects(user, list) }

--- a/spec/features/list_items/grocery_list_items_spec.rb
+++ b/spec/features/list_items/grocery_list_items_spec.rb
@@ -20,10 +20,8 @@ RSpec.describe "A grocery list item", type: :feature do
   end
 
   def confirm_form_cleared
-    expect(list_page.quantity_input.value).to eq ""
-    expect(list_page.quick_add_input.value).to eq ""
-    expect(list_page.category_input.value).to eq ""
-    expect(list_page.completed_checkbox).not_to be_checked
+    # Submitting the add-item modal closes it, which is the form's "cleared" state.
+    expect(list_page).to have_no_add_item_modal
   end
 
   before do

--- a/spec/features/list_items/music_list_items_spec.rb
+++ b/spec/features/list_items/music_list_items_spec.rb
@@ -22,11 +22,8 @@ RSpec.describe "A music list item", type: :feature do
   end
 
   def confirm_form_cleared
-    expect(list_page.quick_add_input.value).to eq ""
-    expect(list_page.artist_input.value).to eq ""
-    expect(list_page.album_input.value).to eq ""
-    expect(list_page.category_input.value).to eq ""
-    expect(list_page.completed_checkbox).not_to be_checked
+    # Submitting the add-item modal closes it, which is the form's "cleared" state.
+    expect(list_page).to have_no_add_item_modal
   end
 
   before do

--- a/spec/features/list_items/simple_list_items_spec.rb
+++ b/spec/features/list_items/simple_list_items_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe "A simple list item", type: :feature do
   end
 
   def confirm_form_cleared
-    expect(list_page.quick_add_input.value).to eq ""
-    expect(list_page.category_input.value).to eq ""
-    expect(list_page.completed_checkbox).not_to be_checked
+    # Submitting the add-item modal closes it, which is the form's "cleared" state.
+    expect(list_page).to have_no_add_item_modal
   end
 
   before do

--- a/spec/features/list_items/to_do_list_items_spec.rb
+++ b/spec/features/list_items/to_do_list_items_spec.rb
@@ -22,11 +22,8 @@ RSpec.describe "A to do list item", type: :feature do
   end
 
   def confirm_form_cleared
-    expect(list_page.quick_add_input.value).to eq ""
-    expect(list_page.assignee_input.value).to eq ""
-    expect(list_page.due_by_input.value).to eq ""
-    expect(list_page.category_input.value).to eq ""
-    expect(list_page.completed_checkbox).not_to be_checked
+    # Submitting the add-item modal closes it, which is the form's "cleared" state.
+    expect(list_page).to have_no_add_item_modal
   end
 
   before do

--- a/spec/support/pages/list.rb
+++ b/spec/support/pages/list.rb
@@ -28,10 +28,11 @@ module Pages
     element :content_input, "#content"
     element :product_input, "#product"
     element :completed_checkbox, "#completed"
-    # The primary/name field is the always-visible bottom input bar (outside the form DOM),
-    # and the form is submitted via the bar's submit button rather than a native submit input.
-    element :quick_add_input, "[data-test-id='quick-add-input']"
-    element :submit_button, "[data-test-id='quick-add-submit']"
+    # The add-item form now lives in a modal opened by the floating "+" button. The primary/name
+    # field renders as a normal form field (testID below) and the form is submitted via the
+    # modal's footer button.
+    element :quick_add_input, "[data-test-id='add-list-item-name-input']"
+    element :submit_button, "[data-test-id='add-list-item-submit']"
     element :close_alert, ".Toastify__close-button.Toastify__close-button--colored"
     element :select_button, "[data-test-id='select-button']"
     element :multi_select_bar, "[data-test-id='multi-select-bar']"
@@ -172,8 +173,18 @@ module Pages
       item_element.find(:css, REFRESH_BUTTON).click
     end
 
+    # Opens the add-item modal via the floating "+" button and waits for it to render.
     def expand_list_item_form
-      find_by_test_id("quick-add-expand").click
+      find_by_test_id("list-add-fab").click
+      wait_for { has_test_id?("add-list-item-modal") }
+    end
+
+    def has_add_item_modal?
+      has_test_id?("add-list-item-modal")
+    end
+
+    def has_no_add_item_modal?
+      has_no_test_id?("add-list-item-modal")
     end
 
     def multi_select_item(item, completed: false)

--- a/spec/support/pages/templates.rb
+++ b/spec/support/pages/templates.rb
@@ -8,16 +8,18 @@ module Pages
     set_url "/templates"
 
     element :header, "h1", text: "Templates"
-    # Templates are created via the always-visible bottom input bar; its submit button is
-    # rendered by the bar (data-test-id) rather than a native submit input.
-    element :submit, "[data-test-id='quick-add-submit']"
+    # Templates are created via a modal opened by the floating "+" button; the submit lives in
+    # the modal footer.
+    element :submit, "[data-test-id='create-template-submit']"
 
     def manage_templates
       find_by_test_id("nav-templates").click
     end
 
+    # Opens the create-template modal via the floating "+" button and waits for it to render.
     def expand_template_form
-      find_by_test_id("quick-add-expand").click
+      find_by_test_id("templates-create-fab").click
+      wait_for { has_test_id?("create-template-modal") }
     end
 
     def has_templates?
@@ -33,7 +35,7 @@ module Pages
     end
 
     def template_name_input
-      find_by_test_id("quick-add-input")
+      find_by_test_id("create-template-name-input")
     end
 
     def field_configuration_rows
@@ -48,8 +50,8 @@ module Pages
     def delete(template_name)
       template_element = find_by_test_class("template", text: template_name)
       trash = find_by_test_id_within(template_element, "template-trash")
-      # The fixed bottom "create template" bar overlaps a freshly added template's actions, so a
-      # normal click is intercepted. Center it and click via JS to trigger the button's handler.
+      # The floating "+" create button can overlap a freshly added template's actions, so a normal
+      # click may be intercepted. Center it and click via JS to trigger the button's handler.
       trash.execute_script("this.scrollIntoView({ block: 'center' }); this.click();")
     end
 

--- a/spec/support/shared_examples/list_items.rb
+++ b/spec/support/shared_examples/list_items.rb
@@ -80,10 +80,10 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
       # Input item attributes
       send("input_new_item_attributes", new_list_item)
       list_page.category_input.set(new_list_item.category)
-      # The category field is now a combobox (client #740); typing an existing category opens a
-      # suggestions dropdown that overlays the fields below it. Dismiss it (Escape preserves the
-      # typed value) so it does not intercept the completed checkbox click.
-      list_page.category_input.send_keys(:escape)
+      # The category field is a combobox (client #740); typing opens a suggestions dropdown that
+      # overlays the fields below it. Blur the field with Tab to close the dropdown so it does not
+      # intercept the completed checkbox click. (Escape would close the whole add-item modal.)
+      list_page.category_input.send_keys(:tab)
 
       # Check the completed checkbox
       list_page.completed_checkbox.click

--- a/spec/support/shared_examples/list_items.rb
+++ b/spec/support/shared_examples/list_items.rb
@@ -96,9 +96,8 @@ RSpec.shared_examples "a list item" do |edit_attribute, template_name, item_clas
       expect(list_page.completed_items.count).to eq initial_completed_items_count + 1
       expect(list_page.not_completed_items.count).to eq @initial_list_item_count
 
-      # Verify form is cleared including the checkbox
+      # Submitting closes the modal (its cleared state); the checkbox no longer exists to assert on.
       send("confirm_form_cleared")
-      expect(list_page.completed_checkbox).not_to be_checked
     end
 
     describe "that is not completed" do


### PR DESCRIPTION
## Why
Following the FAB + modal migration of the add forms:
- **list-detail add-item** (client #753) — `quick-add-expand`/`quick-add-input`/`quick-add-submit` are gone; the form opens in a modal via the floating "+" button.
- **templates create** (client #754) — same migration.

This broke the list-item specs (all types) and several templates specs:
```
Unable to find css "[data-test-id='quick-add-expand']"
```

## What
- **`list.rb`**: `expand_list_item_form` now clicks `list-add-fab` and waits for `add-list-item-modal`; `quick_add_input` → `add-list-item-name-input`, `submit_button` → `add-list-item-submit`; added `has_(no_)add_item_modal?` helpers.
- **`templates.rb`**: `expand_template_form` clicks `templates-create-fab` and waits for `create-template-modal`; `template_name_input` → `create-template-name-input`, `submit` → `create-template-submit`.
- **The modal closes on submit**, so the form's "cleared" state is the modal being gone. Each list-item spec's `confirm_form_cleared` now asserts `have_no_add_item_modal` instead of reading the (now-removed) field inputs, and the shared example drops the trailing `completed_checkbox` assertion for the same reason.
- The primary/name field now renders as a normal form field inside the modal (client #753), so the extended-field selectors (`#quantity`, `#author`, `#category`, `#completed`, …) and the field-row test-ids are unchanged.

## ⚠️ Manual verification
features CI is rubocop-only (green). The e2e suite runs against **staging** — please run the list-items + templates specs once this client is deployed to staging to confirm green.
